### PR TITLE
ShiritoriTopViewのフレーム作成

### DIFF
--- a/shiritori_world/shiritori_world/View/MapView.swift
+++ b/shiritori_world/shiritori_world/View/MapView.swift
@@ -2,30 +2,30 @@ import SwiftUI
 import MapKit
 
 
-//struct MapView: UIViewRepresentable {
-//    @Binding dynamic var lon:Double
-//    @Binding dynamic var lat:Double
-//
-//    func makeUIView(context: UIViewRepresentableContext<MapView>) -> MKMapView {
-//        let view = MKMapView(frame: .zero)
-//
-//        // 初期位置にピンを追加
-//        let annotation = MKPointAnnotation()
-//        annotation.coordinate = CLLocationCoordinate2D(latitude: self.lat, longitude: self.lon)
-//        view.addAnnotation(annotation)
-//        return view
-//    }
-//
-//    func updateUIView(_ uiView: MKMapView, context: UIViewRepresentableContext<MapView>) {
-//        print(uiView.annotations)
-//
-//        // MapAnimationViewの座標が更新された場合、アニメーションで移動させる
-//        if uiView.annotations.count > 0{
-//            let annotation = uiView.annotations[0] as! MKPointAnnotation
-//            let targetPosition = CLLocationCoordinate2D(latitude: self.lat, longitude: self.lon)
-//            UIView.animate(withDuration: 4, animations: {
-//                annotation.coordinate = targetPosition
-//               }, completion: nil)
-//        }
-//    }
-//}
+struct MapView: UIViewRepresentable {
+    @Binding dynamic var lon:Double
+    @Binding dynamic var lat:Double
+
+    func makeUIView(context: UIViewRepresentableContext<MapView>) -> MKMapView {
+        let view = MKMapView(frame: .zero)
+
+        // 初期位置にピンを追加
+        let annotation = MKPointAnnotation()
+        annotation.coordinate = CLLocationCoordinate2D(latitude: self.lat, longitude: self.lon)
+        view.addAnnotation(annotation)
+        return view
+    }
+
+    func updateUIView(_ uiView: MKMapView, context: UIViewRepresentableContext<MapView>) {
+        print(uiView.annotations)
+
+        // MapAnimationViewの座標が更新された場合、アニメーションで移動させる
+        if uiView.annotations.count > 0{
+            let annotation = uiView.annotations[0] as! MKPointAnnotation
+            let targetPosition = CLLocationCoordinate2D(latitude: self.lat, longitude: self.lon)
+            UIView.animate(withDuration: 4, animations: {
+                annotation.coordinate = targetPosition
+               }, completion: nil)
+        }
+    }
+}

--- a/shiritori_world/shiritori_world/View/ShiritoriTopView.swift
+++ b/shiritori_world/shiritori_world/View/ShiritoriTopView.swift
@@ -3,12 +3,38 @@ import SwiftUI
 struct ShiritoriTopView: View{
     @EnvironmentObject var shiritoriFetcher:ShiritoriFetcher
     @ObservedObject var vm = ShiritoriTopViewModel()
+    @State var longitude = 139.745451
+    @State var latitude = 35.658577
     
     var body: some View{
-        Text("ShiritoriTopView")
+        VStack{
+            ShiritoriAnswerView(vm:self.vm)
+            MapView(lon:self.$longitude, lat:self.$latitude)
+        }
     }
 }
 
+
+struct ShiritoriAnswerView:View{
+    @ObservedObject var vm:ShiritoriTopViewModel
+    var body: some View{
+        VStack{
+            Spacer().frame(height:50)
+            Text("現在のワード")
+                .font(.title)
+                .background(Color.gray)
+                .foregroundColor(Color.white)
+            Text("りんご")
+            Spacer().frame(height:50)
+            if(vm.isTurn){
+                TextField("解答入力",text: $vm.word )
+            }
+            Toggle("手番切り替え(開発用)", isOn: $vm.isTurn)
+            Spacer()
+        }.frame(maxWidth:.infinity)
+            .frame(height:300)
+    }
+}
 
 
 

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
@@ -4,6 +4,7 @@ class ShiritoriTopViewModel: ObservableObject {
     @Published var isTurn: Bool = false
     @Published var isValid: Bool = true
     @Published var isHidden: Bool = false
-    @Published var word: String?
+    @Published var word: String = ""
     @Published var shiritori: Shiritori?
+    
 }


### PR DESCRIPTION
ShiritoriTopViewのUI大枠を作成しました。
上下2つのコンポーネントで構成されます。
- しりとり解答View
  - 現在のしりとりワードを表示
  - 手番時のみTextFiledが表示
  - 開発用に手番切り替えトグルを表示
- マップView
  - 現状は指定した一点にマーカーを追加しているのみ

<img src=https://user-images.githubusercontent.com/17425130/85215519-d0653400-b3b4-11ea-8a41-87fca82a99e9.png>
