### PR TITLE
デフォルト位置情報機能を追加

### DIFF
--- a/shiritori_world/shiritori_world/View/MapView.swift
+++ b/shiritori_world/shiritori_world/View/MapView.swift
@@ -71,8 +71,12 @@ struct MapView:UIViewRepresentable{
             
             for i in 0...vm.selection{
                 let word = shiritoriWords[i]
+                // 位置情報み取得のしりとりは表示しない
+                if word.lat < 0{
+                    continue
+                }
                 let annotation = MKPointAnnotation()
-                print(word)
+                
                 let centerCoord =  CLLocationCoordinate2D(latitude:word.lat, longitude: word.long)
                 annotation.title = word.word
                 annotation.coordinate = centerCoord
@@ -87,8 +91,12 @@ struct MapView:UIViewRepresentable{
                 // annotationの描画
                 uiView.addAnnotation(annotation)
             }
-            // 選択されたしりとりに表示位置を合わせる
-            let word = shiritoriWords[vm.selection]
+            // 選択されたしりとりに最も近い位置情報取得可能なしりとりに表示位置を合わせる
+            var selection = vm.selection
+            while (shiritoriWords[selection].lat < 0) && (vm.selection > 0){
+                selection -= 1
+            }
+            let word = shiritoriWords[selection]
             let centerCoord =  CLLocationCoordinate2D(latitude:word.lat, longitude: word.long)
             let span = MKCoordinateSpan(latitudeDelta:1.0, longitudeDelta:1.0)
             let region = MKCoordinateRegion(center:centerCoord, span:span)

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
@@ -12,16 +12,16 @@ class ShiritoriTopViewModel: ObservableObject {
         }
     }
     @Published var id: UUID = UUID()
+    let defaultLon = -1.0
+    let defaultLat = -1.0
     
     let db = Firestore.firestore()
     func send_answer(sf: ShiritoriFetcher, lm: LocationManager, name:String, word:String){
         
         var shiritoriList:[ShiritoriWord] = sf.shiritori.shiritoriWords ?? []
         
-        let lat_default = 35.0
-        let lon_default = 135.0
-        let latitude = lm.location?.latitude ?? lat_default
-        let longitude = lm.location?.longitude ?? lon_default
+        let latitude = lm.location?.latitude ?? self.defaultLon
+        let longitude = lm.location?.longitude ?? self.defaultLat
         shiritoriList.append(
             ShiritoriWord(
                 id:shiritoriList.count + 1,


### PR DESCRIPTION
## 概要
- 位置情報許諾が取れていない場合、デフォルトでlat, lon共に-1が入る仕様に修正
- それらのしりとり情報は地図上では表示されない