### PR TITLE
地図の縮尺を固定

### DIFF
--- a/shiritori_world/shiritori_world/View/MapView.swift
+++ b/shiritori_world/shiritori_world/View/MapView.swift
@@ -90,8 +90,8 @@ struct MapView:UIViewRepresentable{
             // 選択されたしりとりに表示位置を合わせる
             let word = shiritoriWords[vm.selection]
             let centerCoord =  CLLocationCoordinate2D(latitude:word.lat, longitude: word.long)
-            let span = MKCoordinateSpan(latitudeDelta:1.0, longitudeDelta:1.0)
-            let region = MKCoordinateRegion(center:centerCoord, span:span)
+            // let span = MKCoordinateSpan(latitudeDelta:1.0, longitudeDelta:1.0)
+            let region = MKCoordinateRegion(center:centerCoord, span:uiView.region.span)
             uiView.setRegion(region, animated:true)
             
         }


### PR DESCRIPTION
## 概要
ユーザーが地図の縮尺を変えた時、選択しりとりが変更されても縮尺が変更されないようにする。