### PR TITLE
位置情報非表示機能の実装1

### DIFF
--- a/shiritori_world/shiritori_world/View/ContentView.swift
+++ b/shiritori_world/shiritori_world/View/ContentView.swift
@@ -2,22 +2,23 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var sf:ShiritoriFetcher
-    @ObservedObject var vm = ShiritoriTopViewModel()
+    @ObservedObject var topVm = ShiritoriTopViewModel()
+    @ObservedObject var listVm = ShiritoriListViewModel()
     var body: some View {
         TabView{
             // しりとり回答画面
-            ShiritoriTopView(vm:vm)
+            ShiritoriTopView(vm:topVm)
                 .tabItem{
                     Image(systemName:"paperplane")
                     Text("回答画面")
                 }
-            MapFrontView(vm:vm)
+            MapFrontView(vm:topVm)
                 .tabItem{
                     Image(systemName:"mappin.and.ellipse")
                     Text("Map")
             }
             // しりとり履歴画面
-            ShiritoriListView()
+            ShiritoriListView(vm:listVm)
                 .tabItem{
                     Image(systemName:"list.bullet")
                     Text("しりとり履歴")

--- a/shiritori_world/shiritori_world/View/ShiritoriListView.swift
+++ b/shiritori_world/shiritori_world/View/ShiritoriListView.swift
@@ -68,7 +68,7 @@ struct ShiritoriListRows: View{
                         .font(.body)
                         .padding()
                         Text("変更").onTapGesture {
-                            vm.beforeSend(order:shiritoriWord.id, flag_name: "is_location_masked", flag_value:true)
+                            vm.beforeSend(order:shiritoriWord.id)
                         }
                     }
 //                }

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriFetcher.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriFetcher.swift
@@ -6,6 +6,8 @@ class ShiritoriFetcher: ObservableObject{
     @Published var shiritori = Shiritori()
     @Published var user = User()
     let db = Firestore.firestore()
+    lazy var functions = Functions.functions()
+    
     let collection_name = "shiritori"
     
     
@@ -149,7 +151,18 @@ class ShiritoriFetcher: ObservableObject{
             answerDate: answerDate
         )
     }
-    
+
+    func updateShiritoriFlag(order:Int, flag_name:String, flag_value:Bool){
+        print("call updateShiritoriUpdate")
+        let data = ["doc_id":self.user.currentShiritoriID!, "shiritori_order":order, "flag_name":flag_name, "flag_value":flag_value] as [String : Any]
+        self.functions.httpsCallable("updateFlag").call(data){(result, error) in
+            if error != nil{
+                print("udpate shiritori failed:\(String(describing: error))")
+            } else {
+                print("update shiritori succeeded")
+            }
+        }
+    }
 }
 
 struct ShiritoriFetcher_Previews: PreviewProvider {

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
@@ -5,21 +5,20 @@ class ShiritoriListViewModel: ObservableObject {
     @Published var isSent: Bool = false
     @Published var isError: Bool = false
     @Published var order: Int = 0
-    @Published var flag_name:String = "is_location_masked"
-    @Published var flag_value:Bool = true
+    // @Published var flag_name:String = "is_location_masked"
+    // @Published var flag_value:Bool = true
     
-    func beforeSend(order:Int, flag_name:String, flag_value:Bool){
+    func beforeSend(order:Int){
         self.order = order
-        self.flag_name = flag_name
-        self.flag_value = flag_value
+        //  self.flag_name = flag_name
+        // self.flag_value = flag_value
         self.beforeSent = true
     }
     
     func updateShiritoriFlag(sf:ShiritoriFetcher){
-        print("call updateShiritoriUpdate")
-        let data = ["doc_id":sf.user.currentShiritoriID!, "shiritori_order":String(self.order), "flag_name":self.flag_name,
-            // "flag_value":String(self.flag_value)
-            "flag_value": 10
+        print("call updateShiritoriUpdate maskLocation")
+        let flag_list = ["is_location_masked":true, "is_word_masked":true, "is_name_masked":true]
+        let data = ["doc_id":sf.user.currentShiritoriID!, "shiritori_order":String(self.order), "flag_list":flag_list,
         ] as [String : Any]
         print(data)
         sf.functions.httpsCallable("updateFlag").call(data){(result, error) in

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
@@ -1,5 +1,33 @@
 import SwiftUI
 
 class ShiritoriListViewModel: ObservableObject {
-
+    @Published var beforeSent: Bool = false
+    @Published var isSent: Bool = false
+    @Published var isError: Bool = false
+    @Published var order: Int = 0
+    @Published var flag_name:String = "is_location_masked"
+    @Published var flag_value:Bool = true
+    
+    func beforeSend(order:Int, flag_name:String, flag_value:Bool){
+        self.order = order
+        self.flag_name = flag_name
+        self.flag_value = flag_value
+        self.beforeSent = true
+    }
+    
+    func updateShiritoriFlag(sf:ShiritoriFetcher){
+        print("call updateShiritoriUpdate")
+        let data = ["doc_id":sf.user.currentShiritoriID!, "shiritori_order":String(self.order), "flag_name":self.flag_name,
+            // "flag_value":String(self.flag_value)
+            "flag_value": 10
+        ] as [String : Any]
+        print(data)
+        sf.functions.httpsCallable("updateFlag").call(data){(result, error) in
+            if error != nil{
+                print("udpate shiritori failed:\(String(describing: error))")
+            } else {
+                print("update shiritori succeeded")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 概要
- しりとりリスト画面で「全て」と「自分の投稿」を分けて表示できるようにした
- 「自分の投稿」画面に「変更」ボタンを追加し、非表示フラグを設定できるようにした。

## 課題
- 非表示フラグのついたしりとりにマスクをかけて表示するのは未実施