### PR TITLE
初回利用画面を追加

### DIFF
--- a/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
+++ b/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		01F53F1E4D3DCA2A26981B8C /* Pods_shiritori_world_test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 856B1755FAD1EEF1902CC3FE /* Pods_shiritori_world_test.framework */; };
+		2232E048259EF437008023D1 /* FirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E047259EF437008023D1 /* FirstView.swift */; };
+		2232E049259EF437008023D1 /* FirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E047259EF437008023D1 /* FirstView.swift */; };
+		2232E04D259EF80C008023D1 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E04C259EF80C008023D1 /* ContentViewModel.swift */; };
+		2232E04E259EF80C008023D1 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E04C259EF80C008023D1 /* ContentViewModel.swift */; };
 		2249E9B32517431F005A22F9 /* CustomTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2249E9B22517431F005A22F9 /* CustomTextFieldView.swift */; };
 		2263993E2455B741000E835C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2263993D2455B741000E835C /* AppDelegate.swift */; };
 		226399402455B741000E835C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2263993F2455B741000E835C /* SceneDelegate.swift */; };
@@ -52,6 +56,8 @@
 
 /* Begin PBXFileReference section */
 		08A60976C04061918CAA1AA6 /* Pods-shiritori_world_product.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shiritori_world_product.release.xcconfig"; path = "Target Support Files/Pods-shiritori_world_product/Pods-shiritori_world_product.release.xcconfig"; sourceTree = "<group>"; };
+		2232E047259EF437008023D1 /* FirstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstView.swift; sourceTree = "<group>"; };
+		2232E04C259EF80C008023D1 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
 		2249E9B22517431F005A22F9 /* CustomTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomTextFieldView.swift; path = shiritori_world/View/CustomTextFieldView.swift; sourceTree = SOURCE_ROOT; };
 		2263993A2455B741000E835C /* shiritori_world_test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = shiritori_world_test.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2263993D2455B741000E835C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +166,7 @@
 				22A98009246FA4FC006BC8F4 /* ShiritoriTopView.swift */,
 				22A9800B246FA578006BC8F4 /* ShiritoriListView.swift */,
 				22FEB337247A3CB200C1F7B3 /* ContentView.swift */,
+				2232E047259EF437008023D1 /* FirstView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -204,6 +211,7 @@
 				22C84863248A4CC300A6FD98 /* ShiritoriListViewModel.swift */,
 				22A9800E246FA6ED006BC8F4 /* ShiritoriFetcher.swift */,
 				2289B97E2507BFC60005D5AE /* LocationManager.swift */,
+				2232E04C259EF80C008023D1 /* ContentViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -431,12 +439,14 @@
 				22FEB338247A3CB200C1F7B3 /* ContentView.swift in Sources */,
 				22A9800A246FA4FC006BC8F4 /* ShiritoriTopView.swift in Sources */,
 				22C84866248A4F7800A6FD98 /* DataModel.swift in Sources */,
+				2232E048259EF437008023D1 /* FirstView.swift in Sources */,
 				22C84864248A4CC300A6FD98 /* ShiritoriListViewModel.swift in Sources */,
 				22703EF1254E9734004BFB9E /* SettingView.swift in Sources */,
 				22A9800F246FA6ED006BC8F4 /* ShiritoriFetcher.swift in Sources */,
 				22A9800C246FA578006BC8F4 /* ShiritoriListView.swift in Sources */,
 				226399422455B741000E835C /* MapView.swift in Sources */,
 				2249E9B32517431F005A22F9 /* CustomTextFieldView.swift in Sources */,
+				2232E04D259EF80C008023D1 /* ContentViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,12 +461,14 @@
 				22703F2125515009004BFB9E /* ContentView.swift in Sources */,
 				22703F2225515009004BFB9E /* ShiritoriTopView.swift in Sources */,
 				22703F2325515009004BFB9E /* DataModel.swift in Sources */,
+				2232E049259EF437008023D1 /* FirstView.swift in Sources */,
 				22703F2425515009004BFB9E /* ShiritoriListViewModel.swift in Sources */,
 				22F4E67C255168D800B229A2 /* SettingView.swift in Sources */,
 				22703F2525515009004BFB9E /* ShiritoriFetcher.swift in Sources */,
 				22703F2625515009004BFB9E /* ShiritoriListView.swift in Sources */,
 				22703F2725515009004BFB9E /* MapView.swift in Sources */,
 				22703F2825515009004BFB9E /* CustomTextFieldView.swift in Sources */,
+				2232E04E259EF80C008023D1 /* ContentViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/shiritori_world/shiritori_world/View/ContentView.swift
+++ b/shiritori_world/shiritori_world/View/ContentView.swift
@@ -4,35 +4,42 @@ struct ContentView: View {
     @EnvironmentObject var sf:ShiritoriFetcher
     @ObservedObject var topVm = ShiritoriTopViewModel()
     @ObservedObject var listVm = ShiritoriListViewModel()
+    @ObservedObject var contentVm = ContentViewModel()
+    var visit = UserDefaults.standard.bool(forKey: "visit")
+    
     var body: some View {
-        TabView{
-            // しりとり回答画面
-            ShiritoriTopView(vm:topVm)
-                .tabItem{
-                    Image(systemName:"paperplane")
-                    Text("回答画面")
+        if self.visit || contentVm.accepted{
+            TabView{
+                // しりとり回答画面
+                ShiritoriTopView(vm:topVm)
+                    .tabItem{
+                        Image(systemName:"paperplane")
+                        Text("回答画面")
+                    }
+                MapFrontView(vm:topVm)
+                    .tabItem{
+                        Image(systemName:"mappin.and.ellipse")
+                        Text("Map")
                 }
-            MapFrontView(vm:topVm)
-                .tabItem{
-                    Image(systemName:"mappin.and.ellipse")
-                    Text("Map")
+                // しりとり履歴画面
+                ShiritoriListView(vm:listVm)
+                    .tabItem{
+                        Image(systemName:"list.bullet")
+                        Text("しりとり履歴")
+                    }
+                
+                // 設定画面
+                SettingView()
+                    .tabItem{
+                        Image(systemName:"ellipsis")
+                        Text("設定")
+                    }
             }
-            // しりとり履歴画面
-            ShiritoriListView(vm:listVm)
-                .tabItem{
-                    Image(systemName:"list.bullet")
-                    Text("しりとり履歴")
-                }
-            
-            // 設定画面
-            SettingView()
-                .tabItem{
-                    Image(systemName:"ellipsis")
-                    Text("設定")
-                }
+            .onAppear(perform:{
+                self.sf.fetchUserShiritori()
+            })
+        } else{
+            FirstView(vm:contentVm)
         }
-        .onAppear(perform:{
-            self.sf.fetchUserShiritori()
-        })
     }
 }

--- a/shiritori_world/shiritori_world/View/FirstView.swift
+++ b/shiritori_world/shiritori_world/View/FirstView.swift
@@ -10,15 +10,27 @@ import SwiftUI
 
 struct FirstView: View {
     @ObservedObject var vm: ContentViewModel
+    @State var readPolicy:Bool = false
     var visit = UserDefaults.standard.bool(forKey: "visit")
     var body: some View {
         VStack{
-            Button(action:{
-                self.vm.accept_policy()
-            }){
-                Text("accept")
+            Text("本アプリを利用するためには、利用規約に同意する必要があります。下記の利用規約を読み、同意ボタンを押してください。")
+            Spacer().frame(height:30)
+            Text("利用規約").font(.title)
+            Divider()
+            EULAView().frame(height:500)
+            Divider()
+            HStack{
+                Toggle(isOn: $readPolicy){
+                    Text("同意します")
+                }.frame(width:150)
+                Spacer()
             }
-            Text("\(self.visit ? "visit is true": "visit is false")")
+            Button(action:{
+                self.vm.acceptPolicy()
+            }){
+                Text("送信")
+            }.disabled(!readPolicy)
         }
     }
 }

--- a/shiritori_world/shiritori_world/View/FirstView.swift
+++ b/shiritori_world/shiritori_world/View/FirstView.swift
@@ -1,0 +1,24 @@
+//
+//  FirstView.swift
+//  shiritori_world
+//
+//  Created by 辛剣徳 on 2021/01/01.
+//  Copyright © 2021 辛剣徳. All rights reserved.
+//
+
+import SwiftUI
+
+struct FirstView: View {
+    @ObservedObject var vm: ContentViewModel
+    var visit = UserDefaults.standard.bool(forKey: "visit")
+    var body: some View {
+        VStack{
+            Button(action:{
+                self.vm.accept_policy()
+            }){
+                Text("accept")
+            }
+            Text("\(self.visit ? "visit is true": "visit is false")")
+        }
+    }
+}

--- a/shiritori_world/shiritori_world/ViewModel/ContentViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ContentViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 class ContentViewModel: ObservableObject {
     @Published var accepted: Bool = false
     
-    func accept_policy(){
+    func acceptPolicy(){
         self.accepted = true
         UserDefaults.standard.set(true, forKey: "visit")
     }

--- a/shiritori_world/shiritori_world/ViewModel/ContentViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ContentViewModel.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+class ContentViewModel: ObservableObject {
+    @Published var accepted: Bool = false
+    
+    func accept_policy(){
+        self.accepted = true
+        UserDefaults.standard.set(true, forKey: "visit")
+    }
+}
+


### PR DESCRIPTION
## 背景
Appleからのレビューで、「利用規約への同意を明確にユーザーに求める必要がある」と言われたため、対応する。

## 概要
- 初回利用画面を追加した
- 利用規約への同意を求め、同意した場合はしりとり画面に進める
- 初回に同意をすれば、2回目以降は表示されない

## 画面
<img src=https://user-images.githubusercontent.com/17425130/103434906-18f68780-4c4b-11eb-93c3-10dbf7fb286d.png height=600>

## 実装方法
初回起動などのユーザーの利用ログはUserDefaultデータとして持たせるのが適切であるが、  
UserDefaultデータとViewをバインディングしてViewを更新することができない(難しい)ため、  
下記2つのフラグを用意した。
1. 初回に同意したかどうかを示すvisitフラグ -> UserDefault変数
2. 初回起動画面で同意ボタンを押したかどうかを示すacceptフラグ -> State変数
1,2両方の変数がFalseの時のみ、初回利用画面が表示される仕様となっている。
