### PR TITLE
位置情報利用許可のトグルを追加

### DIFF
--- a/shiritori_world/shiritori_world/Model/DataModel.swift
+++ b/shiritori_world/shiritori_world/Model/DataModel.swift
@@ -72,7 +72,10 @@ struct ShiritoriWord:Identifiable{
             "word": self.word,
             "lat": self.lat,
             "long": self.long,
-            "answer_date": self.answerDate
+            "answer_date": self.answerDate,
+            "is_location_masked": self.is_location_masked,
+            "is_name_masked": self.is_name_masked,
+            "is_word_masked": self.is_word_masked
         ]
     }
 }

--- a/shiritori_world/shiritori_world/View/ShiritoriTopView.swift
+++ b/shiritori_world/shiritori_world/View/ShiritoriTopView.swift
@@ -46,8 +46,8 @@ struct topAlertView: View{
         VStack{
             Spacer().alert(isPresented:$vm.beforeSent){
                 Alert(
-                    title: Text("Message"),
-                    message: Text("送信しますか？"),
+                    title: Text("回答を送信"),
+                    message: Text(vm.allowLocation ? "位置情報と合わせて送信されます": "しりとりを送信しますか？"),
                     primaryButton:.default(Text("Yes"),
                         action:{
                             self.vm.send_answer(sf: sf, lm: lm, name: name, word: word)
@@ -57,7 +57,7 @@ struct topAlertView: View{
                 )
             }
             Spacer().alert(isPresented: $vm.isSent) {
-                Alert(title: Text("Message"),
+                Alert(title: Text("送信成功"),
                       message: Text("回答が送信されました！"),
                       dismissButton: .default(Text("OK"),
                           action:{
@@ -68,7 +68,7 @@ struct topAlertView: View{
                 )
             }
             Spacer().alert(isPresented: $vm.isError) {
-                Alert(title: Text("Message"),
+                Alert(title: Text("送信失敗"),
                       message: Text("送信できませんでした"),
                       dismissButton: .default(Text("OK")
                     )
@@ -130,6 +130,12 @@ struct ShiritoriAnswerView:View{
             CustomTextFieldView(title:"回答入力", text: self.$word).border(Color.gray, width:0.5).frame(width:300, height:40)
             if !self.vm.validate(currentWord:self.word, prevWord: String(((self.sf.shiritori.shiritoriWords?.last!.word) ?? "")), name:self.name).isValid{
                 Text(self.vm.validate(currentWord:self.word, prevWord: String(((self.sf.shiritori.shiritoriWords?.last!.word) ?? "")), name:self.name).message)
+            }
+            HStack{
+                Toggle(isOn: $vm.allowLocation){
+                    Text("位置情報も送信する")
+                }.frame(width:250)
+                Spacer()
             }
             Button(action:{
                 self.vm.beforeSend()

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
@@ -6,6 +6,7 @@ class ShiritoriTopViewModel: ObservableObject {
     @Published var beforeSent: Bool = false
     @Published var isSent: Bool = false
     @Published var isError:Bool = false
+    @Published var allowLocation: Bool = true
     @Published var selection: Int = 0 {
         willSet { // selectionが変更された時、選択肢そのものが更新されるようにする
             id = UUID()
@@ -31,8 +32,8 @@ class ShiritoriTopViewModel: ObservableObject {
                 word:word,
                 lat:latitude,
                 long:longitude,
-                answerDate: Date()
-                
+                answerDate: Date(),
+                is_location_masked:!self.allowLocation
             )
         )
         // TODO: monthの自動取得


### PR DESCRIPTION
## 背景
Appleからのフィードバックで「投稿するたび、位置情報の利用許可を確認する必要がある」とのことだったので、対応する

## 概要
- しりとり回答画面に位置情報利用のトグルを追加した
- 位置情報利用がONになっているときは、送信時にさらに確認メッセージを表示するようにした
- firestoreへ送信されるデータに`is_location_masked`を追加した

## 画面
<img src=https://user-images.githubusercontent.com/17425130/103436373-12254000-4c5e-11eb-84d2-8422718c5070.png height=500>

<img src=https://user-images.githubusercontent.com/17425130/103436414-66c8bb00-4c5e-11eb-90a7-803b3a50d6ac.png height=500>



