### PR TITLE
通報機能を追加

### DIFF
--- a/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
+++ b/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2232E049259EF437008023D1 /* FirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E047259EF437008023D1 /* FirstView.swift */; };
 		2232E04D259EF80C008023D1 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E04C259EF80C008023D1 /* ContentViewModel.swift */; };
 		2232E04E259EF80C008023D1 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E04C259EF80C008023D1 /* ContentViewModel.swift */; };
+		2232E056259F3D48008023D1 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E055259F3D48008023D1 /* MapViewModel.swift */; };
+		2232E057259F3D48008023D1 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2232E055259F3D48008023D1 /* MapViewModel.swift */; };
 		2249E9B32517431F005A22F9 /* CustomTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2249E9B22517431F005A22F9 /* CustomTextFieldView.swift */; };
 		2263993E2455B741000E835C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2263993D2455B741000E835C /* AppDelegate.swift */; };
 		226399402455B741000E835C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2263993F2455B741000E835C /* SceneDelegate.swift */; };
@@ -58,6 +60,7 @@
 		08A60976C04061918CAA1AA6 /* Pods-shiritori_world_product.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shiritori_world_product.release.xcconfig"; path = "Target Support Files/Pods-shiritori_world_product/Pods-shiritori_world_product.release.xcconfig"; sourceTree = "<group>"; };
 		2232E047259EF437008023D1 /* FirstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstView.swift; sourceTree = "<group>"; };
 		2232E04C259EF80C008023D1 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
+		2232E055259F3D48008023D1 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		2249E9B22517431F005A22F9 /* CustomTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CustomTextFieldView.swift; path = shiritori_world/View/CustomTextFieldView.swift; sourceTree = SOURCE_ROOT; };
 		2263993A2455B741000E835C /* shiritori_world_test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = shiritori_world_test.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2263993D2455B741000E835C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -211,6 +214,7 @@
 				22C84863248A4CC300A6FD98 /* ShiritoriListViewModel.swift */,
 				22A9800E246FA6ED006BC8F4 /* ShiritoriFetcher.swift */,
 				2289B97E2507BFC60005D5AE /* LocationManager.swift */,
+				2232E055259F3D48008023D1 /* MapViewModel.swift */,
 				2232E04C259EF80C008023D1 /* ContentViewModel.swift */,
 			);
 			path = ViewModel;
@@ -439,6 +443,7 @@
 				22FEB338247A3CB200C1F7B3 /* ContentView.swift in Sources */,
 				22A9800A246FA4FC006BC8F4 /* ShiritoriTopView.swift in Sources */,
 				22C84866248A4F7800A6FD98 /* DataModel.swift in Sources */,
+				2232E056259F3D48008023D1 /* MapViewModel.swift in Sources */,
 				2232E048259EF437008023D1 /* FirstView.swift in Sources */,
 				22C84864248A4CC300A6FD98 /* ShiritoriListViewModel.swift in Sources */,
 				22703EF1254E9734004BFB9E /* SettingView.swift in Sources */,
@@ -461,6 +466,7 @@
 				22703F2125515009004BFB9E /* ContentView.swift in Sources */,
 				22703F2225515009004BFB9E /* ShiritoriTopView.swift in Sources */,
 				22703F2325515009004BFB9E /* DataModel.swift in Sources */,
+				2232E057259F3D48008023D1 /* MapViewModel.swift in Sources */,
 				2232E049259EF437008023D1 /* FirstView.swift in Sources */,
 				22703F2425515009004BFB9E /* ShiritoriListViewModel.swift in Sources */,
 				22F4E67C255168D800B229A2 /* SettingView.swift in Sources */,

--- a/shiritori_world/shiritori_world/View/ContentView.swift
+++ b/shiritori_world/shiritori_world/View/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var sf:ShiritoriFetcher
     @ObservedObject var topVm = ShiritoriTopViewModel()
+    @ObservedObject var mapVm = MapViewModel()
     @ObservedObject var listVm = ShiritoriListViewModel()
     @ObservedObject var contentVm = ContentViewModel()
     var visit = UserDefaults.standard.bool(forKey: "visit")
@@ -16,7 +17,7 @@ struct ContentView: View {
                         Image(systemName:"paperplane")
                         Text("回答画面")
                     }
-                MapFrontView(vm:topVm)
+                MapFrontView(vm:mapVm)
                     .tabItem{
                         Image(systemName:"mappin.and.ellipse")
                         Text("Map")

--- a/shiritori_world/shiritori_world/View/ShiritoriListView.swift
+++ b/shiritori_world/shiritori_world/View/ShiritoriListView.swift
@@ -29,11 +29,33 @@ struct ShiritoriListRows: View{
     @Binding var selectedStyle:Int
     var body: some View{
         if (selectedStyle == 0){
-            List(self.sf.shiritori.shiritoriWords!){ shiritoriWord in
-                VStack(alignment: .leading){
-                Text("順番:\(shiritoriWord.id)")
-                .font(.body)
-                .padding(5)
+            ShiritoriListRowsAll(vm: vm)
+        } else if (selectedStyle == 1){
+            ShiritoriListRowsUser(vm: vm)
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+struct ShiritoriListRowsAll: View{
+    @EnvironmentObject var sf:ShiritoriFetcher
+    @ObservedObject var vm: ShiritoriListViewModel
+    var body: some View{
+        List(self.sf.shiritori.shiritoriWords!){ shiritoriWord in
+            VStack(alignment: .leading){
+                HStack{
+                    Text("順番:\(shiritoriWord.id)")
+                    .font(.body)
+                    .padding(5)
+                    Spacer()
+                    Text("通報")
+                        .foregroundColor(Color.blue)
+                        .font(.subheadline)
+                        .onTapGesture {
+                        vm.reportBeforeSend(order: shiritoriWord.id)
+                    }
+                }
                     Text("回答者:\(shiritoriWord.masked_name ?? "取得中...")")
                 .font(.body)
                 .padding(5)
@@ -46,30 +68,37 @@ struct ShiritoriListRows: View{
                 Text("回答日時:\(shiritoriWord.answerDateStr)")
                 .font(.body)
                 .padding(5)
-                }
-            }.navigationBarTitle("しりとり履歴", displayMode: .inline)
-        } else if (selectedStyle == 1){
-            List(self.sf.shiritori.shiritoriWords!.filter{$0.userID == sf.user.userID}){ shiritoriWord in
-                    VStack(alignment: .leading){
-                        HStack{
-                            Text("順番:\(shiritoriWord.id)")
-                            .font(.body)
-                            .padding(5)
-                            Spacer()
-                            Group{
-                                if shiritoriWord.is_location_masked{
-                                    Image(systemName:"lock.fill")
-                                } else {
-                                    Image(systemName:"lock.open.fill")
-                                }
-                            }.onTapGesture {
-                                vm.beforeSend(order: shiritoriWord.id, is_masked: shiritoriWord.is_location_masked)
-                            }
-                        }
-                            Text("回答者:\(shiritoriWord.name ?? "取得中...")")
+            }
+        }.navigationBarTitle("しりとり履歴", displayMode: .inline)
+    }
+}
+
+struct ShiritoriListRowsUser: View{
+    @EnvironmentObject var sf:ShiritoriFetcher
+    @ObservedObject var vm: ShiritoriListViewModel
+    var body: some View{
+        List(self.sf.shiritori.shiritoriWords!.filter{$0.userID == sf.user.userID}){ shiritoriWord in
+                VStack(alignment: .leading){
+                    HStack{
+                        Text("順番:\(shiritoriWord.id)")
                         .font(.body)
                         .padding(5)
-                            Text("回答場所:\(shiritoriWord.address ?? "???")")
+                        Spacer()
+                        Group{
+                            if shiritoriWord.is_location_masked{
+                                Image(systemName:"lock.fill")
+                            } else {
+                                Image(systemName:"lock.open.fill")
+                            }
+                        }.onTapGesture {
+                            vm.updateBeforeSend(order: shiritoriWord.id, is_masked: shiritoriWord.is_location_masked)
+                        }
+                    }
+                    VStack(alignment: .leading){
+                        Text("回答者:\(shiritoriWord.name ?? "取得中...")")
+                        .font(.body)
+                        .padding(5)
+                        Text("回答場所:\(shiritoriWord.address ?? "???")")
                         .font(.body)
                         .padding(5)
                         Text("回答ワード:\(shiritoriWord.word)")
@@ -79,10 +108,8 @@ struct ShiritoriListRows: View{
                         .font(.body)
                         .padding(5)
                     }
-            }.navigationBarTitle("しりとり履歴", displayMode: .inline)
-        } else {
-            EmptyView()
-        }
+                }
+        }.navigationBarTitle("しりとり履歴", displayMode: .inline)
     }
 }
 
@@ -91,13 +118,25 @@ struct listAlertView: View{
     @EnvironmentObject var sf:ShiritoriFetcher
     
     var body: some View{
-        Spacer().alert(isPresented:$vm.beforeSent){
+        Spacer().alert(isPresented:$vm.updateBeforeSent){
             Alert(
                 title: Text("Message"),
                 message: Text(vm.is_masked ? "投稿を公開しますか？":"投稿を非公開にしますか？"),
                 primaryButton: .default(Text("Yes"),
                                         action:{
                                             vm.updateShiritoriFlag(sf:sf)
+                                        }),
+                secondaryButton: .cancel(Text("cancel"))
+                
+            )
+        }
+        Spacer().alert(isPresented:$vm.reportBeforeSent){
+            Alert(
+                title: Text("Message"),
+                message: Text("この投稿を通報しますか？"),
+                primaryButton: .default(Text("Yes"),
+                                        action:{
+                                            vm.reportShiritori(sf:sf)
                                         }),
                 secondaryButton: .cancel(Text("cancel"))
                 

--- a/shiritori_world/shiritori_world/View/ShiritoriListView.swift
+++ b/shiritori_world/shiritori_world/View/ShiritoriListView.swift
@@ -59,15 +59,11 @@ struct ShiritoriListRows: View{
                             Group{
                                 if shiritoriWord.is_location_masked{
                                     Image(systemName:"lock.fill")
-                                        .onTapGesture {
-                                            vm.beforeSend(order: shiritoriWord.id, is_masked: shiritoriWord.is_location_masked)
-                                        }
                                 } else {
                                     Image(systemName:"lock.open.fill")
-                                        .onTapGesture {
-                                        vm.beforeSend(order:shiritoriWord.id, is_masked: shiritoriWord.is_location_masked)
-                                        }
                                 }
+                            }.onTapGesture {
+                                vm.beforeSend(order: shiritoriWord.id, is_masked: shiritoriWord.is_location_masked)
                             }
                         }
                             Text("回答者:\(shiritoriWord.name ?? "取得中...")")

--- a/shiritori_world/shiritori_world/ViewModel/MapViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/MapViewModel.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import Firebase
+
+class MapViewModel: ObservableObject {
+    @Published var reportBeforeSent: Bool = false
+    @Published var isSent: Bool = false
+    @Published var isError:Bool = false
+    @Published var selection: Int = 0 {
+        willSet { // selectionが変更された時、選択肢そのものが更新されるようにする
+            id = UUID()
+        }
+    }
+    @Published var id: UUID = UUID()
+    var selected_order: Int = 0
+    let collection_name = "shiritori"
+    
+    func reportBeforeSend(){
+        self.reportBeforeSent = true
+    }
+    
+    func reportShiritori(sf: ShiritoriFetcher, order: Int){
+        print("call reportShiritori")
+        let flag_list = ["is_reported":true]
+        let data  = ["doc_id":sf.user.currentShiritoriID!, "shiritori_order":String(order), "flag_list":flag_list,
+        ] as [String : Any]
+        print(data)
+        sf.functions.httpsCallable("updateFlag").call(data){(result, error) in
+            if error != nil{
+                self.isError = true
+                print("report shiritori failed:\(String(describing: error))")
+            } else {
+                self.isSent = true
+                print("report shiritori succeeded")
+            }
+        }
+    }
+}

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriListViewModel.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 class ShiritoriListViewModel: ObservableObject {
-    @Published var beforeSent: Bool = false
+    @Published var updateBeforeSent: Bool = false
+    @Published var reportBeforeSent: Bool = false
     @Published var isSent: Bool = false
     @Published var isError: Bool = false
     @Published var order: Int = 0
@@ -9,10 +10,15 @@ class ShiritoriListViewModel: ObservableObject {
     // @Published var flag_name:String = "is_location_masked"
     // @Published var flag_value:Bool = true
     
-    func beforeSend(order:Int, is_masked:Bool){
+    func updateBeforeSend(order:Int, is_masked:Bool){
         self.order = order
         self.is_masked = is_masked
-        self.beforeSent = true
+        self.updateBeforeSent = true
+    }
+    
+    func reportBeforeSend(order:Int){
+        self.order = order
+        self.reportBeforeSent = true
     }
     
     func updateShiritoriFlag(sf:ShiritoriFetcher){
@@ -29,6 +35,23 @@ class ShiritoriListViewModel: ObservableObject {
             } else {
                 self.isSent = true
                 print("update shiritori succeeded")
+            }
+        }
+    }
+    
+    func reportShiritori(sf: ShiritoriFetcher){
+        print("call reportShiritori")
+        let flag_list = ["is_reported":true]
+        let data  = ["doc_id":sf.user.currentShiritoriID!, "shiritori_order":String(self.order), "flag_list":flag_list,
+        ] as [String : Any]
+        print(data)
+        sf.functions.httpsCallable("updateFlag").call(data){(result, error) in
+            if error != nil{
+                self.isError = true
+                print("report shiritori failed:\(String(describing: error))")
+            } else {
+                self.isSent = true
+                print("report shiritori succeeded")
             }
         }
     }

--- a/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
+++ b/shiritori_world/shiritori_world/ViewModel/ShiritoriTopViewModel.swift
@@ -7,16 +7,9 @@ class ShiritoriTopViewModel: ObservableObject {
     @Published var isSent: Bool = false
     @Published var isError:Bool = false
     @Published var allowLocation: Bool = true
-    @Published var selection: Int = 0 {
-        willSet { // selectionが変更された時、選択肢そのものが更新されるようにする
-            id = UUID()
-        }
-    }
-    @Published var id: UUID = UUID()
     let defaultLon = -999.0
     let defaultLat = -999.0
     let collection_name = "shiritori"
-    
     let db = Firestore.firestore()
     func send_answer(sf: ShiritoriFetcher, lm: LocationManager, name:String, word:String){
         
@@ -149,4 +142,5 @@ extension String {
     func get_order(sf: ShiritoriFetcher)->Int{
         return (sf.shiritori.shiritoriWords?.count ?? 0  + 1)
     }
+
 }


### PR DESCRIPTION
## 概要
Appleフィードバックに対応するため、しりとり投稿を通報する機能を追加した。

## 概要
- 地図画面に通報ボタンを設置
- しりとりリスト画面に通報ボタンを設置
- ボタンが押されると、当該しりとりの`is_reported`フラグがTrueになる

## 画面
<image src=https://user-images.githubusercontent.com/17425130/103438166-71417f80-4c73-11eb-8782-1b7a791b84ab.png height=500>

<image src=https://user-images.githubusercontent.com/17425130/103438164-6b4b9e80-4c73-11eb-81a3-0079060b9630.png height=500>

<image src=https://user-images.githubusercontent.com/17425130/103438182-ae0d7680-4c73-11eb-9b00-5f57ad9553e1.png height=500>


