### PR TITLE
初回起動画面のバグ対応

### DIFF
--- a/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
+++ b/shiritori_world/shiritori_world.xcodeproj/project.pbxproj
@@ -665,7 +665,7 @@
 				CODE_SIGN_ENTITLEMENTS = shiritori_world/shiritori_world.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"shiritori_world/Preview Content\"";
 				DEVELOPMENT_TEAM = 2L366MW7UT;
 				ENABLE_PREVIEWS = YES;
@@ -691,7 +691,7 @@
 				CODE_SIGN_ENTITLEMENTS = shiritori_world/shiritori_world.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_ASSET_PATHS = "\"shiritori_world/Preview Content\"";
 				DEVELOPMENT_TEAM = 2L366MW7UT;
 				ENABLE_PREVIEWS = YES;

--- a/shiritori_world/shiritori_world/View/FirstView.swift
+++ b/shiritori_world/shiritori_world/View/FirstView.swift
@@ -14,11 +14,12 @@ struct FirstView: View {
     var visit = UserDefaults.standard.bool(forKey: "visit")
     var body: some View {
         VStack{
+            Spacer().frame(height:30)
             Text("本アプリを利用するためには、利用規約に同意する必要があります。下記の利用規約を読み、同意ボタンを押してください。")
             Spacer().frame(height:30)
             Text("利用規約").font(.title)
             Divider()
-            EULAView().frame(height:500)
+            EULAView()
             Divider()
             HStack{
                 Toggle(isOn: $readPolicy){
@@ -31,6 +32,7 @@ struct FirstView: View {
             }){
                 Text("送信")
             }.disabled(!readPolicy)
+            Spacer().frame(height:50)
         }
     }
 }

--- a/shiritori_world/shiritori_world/View/SettingView.swift
+++ b/shiritori_world/shiritori_world/View/SettingView.swift
@@ -3,6 +3,8 @@ import WebKit
 
 struct SettingView: View {
     @State var showModal = false
+    var versionLabel = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
+    var buildLabel = Bundle.main.infoDictionary!["CFBundleVersion"] as! String
     init() {
             UINavigationBar.appearance().titleTextAttributes = [.font : UIFont(name: "Thonburi-Bold", size: 20)!]
     }
@@ -65,7 +67,8 @@ struct SettingView: View {
                     Image(systemName:"gear")
                         .foregroundColor(.black)
                     Spacer()
-                    Text("ver 1.0.6")
+                        Text("ver \(self.versionLabel).\(self.buildLabel)")
+                    // Text("ver 1.0.6")
                     Spacer().frame(width: 15)
                         }
                 }


### PR DESCRIPTION
## 概要
- Iphone7, 8において初回起動画面が正しく表示されないバグが発生していたので対応
- Buildバージョンを7->8に更新
- ついでに設定画面のバージョン名を設定ファイルから動的に取得する機能を追加